### PR TITLE
Banner Iframe Resize Override

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -142,3 +142,39 @@ function blabber_child_override_avatar_function() {
     add_filter('get_avatar', 'blabber_child_safe_avatar', 10, 5);
 }
 add_action('init', 'blabber_child_override_avatar_function', 1);
+
+/**
+ * Prevent Blabber theme from resizing banner container iframes
+ * This allows banners to maintain their original dimensions
+ */
+function blabber_child_exclude_banner_iframes_from_resizing() {
+    ?>
+    <script type="text/javascript">
+    document.addEventListener("DOMContentLoaded", function() {
+        // Override theme's iframe resize function to exclude banner iframes
+        if (typeof blabber_resize_video === 'function') {
+            var original_blabber_resize_video = blabber_resize_video;
+            
+            blabber_resize_video = function(cont) {
+                if (cont === undefined) {
+                    cont = jQuery('body');
+                }
+                
+                // Get all iframe elements that would normally be resized
+                var iframes = cont.find('.video_frame iframe, .page_content_wrap iframe');
+                
+                // Exclude banner container iframes from resizing
+                var banner_iframes = iframes.filter('.iwz-footer-banner iframe, .iwz-head-banner iframe, .iwz-content-banner iframe, .iwz-sidebar-banner iframe, .iwz-menu-banner iframe, .iwz-blabber-footer-banner iframe, .iwz-blabber-header-banner iframe');
+                
+                // Mark banner iframes to prevent theme resizing
+                banner_iframes.addClass('trx_addons_noresize blabber_noresize');
+                
+                // Call original resize function
+                original_blabber_resize_video.call(this, cont);
+            };
+        }
+    });
+    </script>
+    <?php
+}
+add_action('wp_footer', 'blabber_child_exclude_banner_iframes_from_resizing', 1); // Early priority

--- a/functions.php
+++ b/functions.php
@@ -175,8 +175,12 @@ function blabber_child_prevent_banner_iframe_resizing() {
                 this.style.setProperty('width', originalWidth + 'px', 'important');
                 this.style.setProperty('height', originalHeight + 'px', 'important');
                 
-                // Also set margin and padding to prevent spacing issues
-                this.style.setProperty('margin', '0', 'important');
+                // Set margin and padding - use auto margins for centering blabber footer banners
+                if ($iframe.closest('.iwz-blabber-footer-banner').length > 0) {
+                    this.style.setProperty('margin', '0 auto', 'important');
+                } else {
+                    this.style.setProperty('margin', '0', 'important');
+                }
                 this.style.setProperty('padding', '0', 'important');
                 this.style.setProperty('display', 'block', 'important');
                 this.style.setProperty('vertical-align', 'top', 'important');


### PR DESCRIPTION
This pull request introduces a new function to prevent the Blabber theme from resizing banner container iframes, ensuring banners maintain their original dimensions.

Key changes:

### Theme customization for iframe resizing:
* [`functions.php`](diffhunk://#diff-01c9525afc2c87cfcb03124117c9d0ebb067029f6c955a607fa0fd4274aca556R145-R180): Added the `blabber_child_exclude_banner_iframes_from_resizing` function, which overrides the theme's iframe resize functionality to exclude banner container iframes. Banner iframes are marked with specific classes (`trx_addons_noresize` and `blabber_noresize`) to prevent resizing, and the modified function is executed early via the `wp_footer` action.